### PR TITLE
added did:shib method

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const Constants = Object.freeze({
 export enum Blockchain {
   Ethereum = 'eth',
   Polygon = 'polygon',
+  Shibarium = 'shibarium',
   ZkEVM = 'zkevm',
   Unknown = 'unknown',
   NoChain = '',
@@ -56,6 +57,7 @@ export enum NetworkId {
   Mumbai = 'mumbai',
   Goerli = 'goerli',
   Sepolia = 'sepolia',
+  PuppyNet = 'puppynet',
   Test = 'test',
   Unknown = 'unknown',
   NoNetwork = ''
@@ -64,12 +66,14 @@ export enum NetworkId {
 export enum DidMethod {
   Iden3 = 'iden3',
   PolygonId = 'polygonid',
+  Shib = 'shib',
   Other = ''
 }
 
 export const DidMethodByte: { [key: string]: number } = Object.freeze({
   [DidMethod.Iden3]: 0b00000001,
   [DidMethod.PolygonId]: 0b00000010,
+  [DidMethod.Shib]: 0b00000011,
   [DidMethod.Other]: 0b11111111
 });
 
@@ -96,6 +100,11 @@ export const DidMethodNetwork: {
     [`${Blockchain.Ethereum}:${NetworkId.Sepolia}`]: 0b00100000 | 0b00000011,
     [`${Blockchain.ZkEVM}:${NetworkId.Main}`]: 0b00110000 | 0b00000001,
     [`${Blockchain.ZkEVM}:${NetworkId.Test}`]: 0b00110000 | 0b00000010
+  },
+  [DidMethod.Shib]: {
+    [`${Blockchain.ReadOnly}:${NetworkId.NoNetwork}`]: 0b00000000,
+    [`${Blockchain.Shibarium}:${NetworkId.Main}`]: 0b01000000 | 0b00000001,
+    [`${Blockchain.Shibarium}:${NetworkId.PuppyNet}`]: 0b01000000 | 0b00000010,
   },
   [DidMethod.Other]: {
     [`${Blockchain.Unknown}:${NetworkId.Unknown}`]: 0b11111111

--- a/tests/did.test.ts
+++ b/tests/did.test.ts
@@ -45,6 +45,36 @@ describe('DID tests', () => {
     expect(Uint8Array.from([DidMethodByte[DidMethod.Iden3], 0b0])).toStrictEqual(id.type());
   });
 
+  it('TestParseShibDID', () => {
+    // did
+    let didStr = 'did:shib:shibarium:main:3suph5aVnT3uDycoQqtYjm5eJx2295k3L5XeHXd8Kq';
+
+    let did3 = DID.parse(didStr);
+    let id = DID.idFromDID(did3);
+    expect('3suph5aVnT3uDycoQqtYjm5eJx2295k3L5XeHXd8Kq').toEqual(id.string());
+    let method = DID.methodFromId(id);
+    expect(DidMethod.Shib).toBe(method);
+    let blockchain = DID.blockchainFromId(id);
+    expect(Blockchain.Shibarium).toBe(blockchain);
+    let networkId = DID.networkIdFromId(id);
+    expect(NetworkId.Main).toBe(networkId);
+
+    // readonly did
+    didStr = 'did:shib:readonly:3etR8HpjUyg29h5ssFaTghiBezcpmhidcZ6Z5WuNr3';
+
+    did3 = DID.parse(didStr);
+    id = DID.idFromDID(did3);
+    expect('3etR8HpjUyg29h5ssFaTghiBezcpmhidcZ6Z5WuNr3').toBe(id.string());
+    method = DID.methodFromId(id);
+    expect(DidMethod.Shib).toBe(method);
+    blockchain = DID.blockchainFromId(id);
+    expect(Blockchain.ReadOnly).toBe(blockchain);
+    networkId = DID.networkIdFromId(id);
+    expect(NetworkId.NoNetwork).toBe(networkId);
+
+    expect(Uint8Array.from([DidMethodByte[DidMethod.Shib], 0b0])).toStrictEqual(id.type());
+  });
+
   it('TestDID_UnmarshalJSON', () => {
     const parseRes = JSON.parse(
       `{"obj": "did:iden3:polygon:mumbai:wyFiV4w71QgWPn6bYLsZoysFay66gKtVa9kfu6yMZ"}`


### PR DESCRIPTION
Add support for Shibarium to polygonID

## Description
Add support for did:shib method, Shibarium chain, Main and Puppynet networks

## Related Issue
https://shibaone.atlassian.net/browse/SHYDENTITY-8?atlOrigin=eyJpIjoiMjllYjk3OWQwODFlNDhhN2FlODM2MzVlOTU2MTk1MWIiLCJwIjoiaiJ9

## Motivation and Context
Adds support for Shibarium to polygonID

## How Has This Been Tested?
Unit test
